### PR TITLE
Issue #10 - Added permission for FOREGROUND_SERVICE

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -20,6 +20,9 @@
                 <param name="android-package" value="com.davidbriglio.foreground.ForegroundPlugin" />
             </feature>
         </config-file>
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+        </config-file>
     </platform>
 
     <!-- Only android 26+ is accepted -->


### PR DESCRIPTION
Fixes issue for Android SDK 28+ which require foreground service permissions.